### PR TITLE
Prevent duplicate action runs when pushing to PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,11 @@
 # Finally, If the compiled files have been pushed out to the "(something)/build/libs/" directory - It gets uploaded to GitHub.
 
 name: Build GoofyPlugin with Gradle
-on: [push, pull_request]
+on:
+    push:
+      branches:
+        - main
+    pull_request:
 
 jobs:
   build:

--- a/.github/workflows/email-check.yml
+++ b/.github/workflows/email-check.yml
@@ -1,5 +1,9 @@
 name: Ensure TheKillerBunny's email is not exposed
-on: [pull_request, push]
+on:
+    push:
+      branches:
+        - main
+    pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
This makes it so actions only happen on pull request related stuff and pushes to `main`