### PR TITLE
Add IntelliJ app

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,8 @@ org.gradle.jvmargs=-Xmx2048M
 java_version=17
 
 minecraft_version=1.20.1
+minecraft_version_out=1.20.1
+loom_version=1.2-SNAPSHOT
 mappings=1
 enabled_platforms=fabric
 
@@ -21,7 +23,7 @@ authors = TheKillerBunny, PoolloverNathan
 # https://fabricmc.net/develop
 # https://modrinth.com/mod/fabric-api
 fabric_loader_version=0.14.21
-fabric_api_version=0.97.0
+fabric_api_version=0.83.0
 
 # Figura Version
 # https://maven.figuramc.org/#/releases/org/figuramc/figura-common-intermediary


### PR DESCRIPTION
Adds the `.#idea` app which launches a preconfigured IntelliJ. It (should) also come with MinecraftDev preinstalled, making mixins a lot easier.
