### PR TITLE
fix: don't print a log message when GUI element status is changed

### DIFF
--- a/common/src/main/java/com/thekillerbunny/goofyplugin/lua/GoofyAPI.java
+++ b/common/src/main/java/com/thekillerbunny/goofyplugin/lua/GoofyAPI.java
@@ -327,7 +327,6 @@ public class GoofyAPI {
 
         try {
             Enums.GuiElement element = Enums.GuiElement.valueOf(guiElement);
-            GoofyPlugin.LOGGER.info("Setting element " + element.toString() + " rendering to " + !disableRender);
             GoofyPlugin.disabledElements.put(element, disableRender);
         }catch (IllegalArgumentException e) {
             throw new LuaError("Could not find element with name " + guiElement);


### PR DESCRIPTION
fox hit Prism's log limit and the log file is several megabytes
