### PR TITLE
Add an event for modifying sign text

### DIFF
--- a/common/src/main/java/com/thekillerbunny/goofyplugin/ducks/AvatarAccessor.java
+++ b/common/src/main/java/com/thekillerbunny/goofyplugin/ducks/AvatarAccessor.java
@@ -1,0 +1,13 @@
+package com.thekillerbunny.goofyplugin.ducks;
+
+import org.figuramc.figura.avatar.Avatar;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.Queue;
+
+@Mixin(value = Avatar.class, remap = false)
+public interface AvatarAccessor {
+    @Accessor
+    Queue<Runnable> getEvents();
+}

--- a/common/src/main/java/com/thekillerbunny/goofyplugin/mixin/EventsAPIMixin.java
+++ b/common/src/main/java/com/thekillerbunny/goofyplugin/mixin/EventsAPIMixin.java
@@ -4,6 +4,7 @@ import org.figuramc.figura.lua.LuaWhitelist;
 import org.figuramc.figura.lua.api.event.EventsAPI;
 import org.figuramc.figura.lua.api.event.LuaEvent;
 import org.figuramc.figura.lua.docs.LuaFieldDoc;
+import org.luaj.vm2.Lua;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -37,15 +38,22 @@ public class EventsAPIMixin implements EventsAPIAccess {
     @LuaFieldDoc("events.early_render")
     public LuaEvent PRE_RENDER;
 
+    @Unique
+    @LuaWhitelist
+    @LuaFieldDoc("events.early_render")
+    public LuaEvent PARTICLE_CREATED;
+
     @Inject(method = "<init>", at = @At("RETURN"))
     void a(CallbackInfo ci) {
         ERROR = new LuaEvent();
         ENTITY_RENDER = new LuaEvent();
         PRE_RENDER = new LuaEvent();
+        PARTICLE_CREATED = new LuaEvent();
 
         events.put("ERROR", ERROR);
         events.put("ENTITY_RENDER", ENTITY_RENDER);
         events.put("PRE_RENDER", PRE_RENDER);
+        events.put("PARTICLE_CREATED", PARTICLE_CREATED);
     }
 
     @Override

--- a/common/src/main/java/com/thekillerbunny/goofyplugin/mixin/EventsAPIMixin.java
+++ b/common/src/main/java/com/thekillerbunny/goofyplugin/mixin/EventsAPIMixin.java
@@ -43,17 +43,24 @@ public class EventsAPIMixin implements EventsAPIAccess {
     @LuaFieldDoc("events.early_render")
     public LuaEvent PARTICLE_CREATED;
 
+    @Unique
+    @LuaWhitelist
+    @LuaFieldDoc("events.sign_update")
+    public LuaEvent SIGN_UPDATE;
+
     @Inject(method = "<init>", at = @At("RETURN"))
     void a(CallbackInfo ci) {
         ERROR = new LuaEvent();
         ENTITY_RENDER = new LuaEvent();
         PRE_RENDER = new LuaEvent();
         PARTICLE_CREATED = new LuaEvent();
+        SIGN_UPDATE = new LuaEvent(true);
 
         events.put("ERROR", ERROR);
         events.put("ENTITY_RENDER", ENTITY_RENDER);
         events.put("PRE_RENDER", PRE_RENDER);
         events.put("PARTICLE_CREATED", PARTICLE_CREATED);
+        events.put("SIGN_UPDATE", SIGN_UPDATE);
     }
 
     @Override

--- a/common/src/main/java/com/thekillerbunny/goofyplugin/mixin/FiguraFutureMixin.java
+++ b/common/src/main/java/com/thekillerbunny/goofyplugin/mixin/FiguraFutureMixin.java
@@ -1,0 +1,53 @@
+package com.thekillerbunny.goofyplugin.mixin;
+
+import com.mojang.datafixers.util.Either;
+import com.thekillerbunny.goofyplugin.nomixinducks.FiguraFutureMixinAccess;
+import org.figuramc.figura.lua.api.data.FiguraFuture;
+import org.luaj.vm2.LuaError;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Consumer;
+
+@Mixin(FiguraFuture.class)
+public class FiguraFutureMixin<T> implements FiguraFutureMixinAccess<T> {
+    @Shadow private LuaError errorObject;
+    @Unique Set<Consumer<Either<Throwable, T>>> goofyplugin$handlers;
+
+    @Inject(at = @At("TAIL"), method = "<init>")
+    void init(CallbackInfo ci) {
+        goofyplugin$handlers = new HashSet<>();
+    }
+
+    @Inject(at = @At("TAIL"), method = "complete")
+    void onComplete(T value, CallbackInfo ci) {
+        for (var handler: goofyplugin$handlers) {
+            handler.accept(Either.right(value));
+        }
+        goofyplugin$handlers = null;
+    }
+
+    @Inject(at = @At("TAIL"), method = "error")
+    void onError(Throwable t, CallbackInfo ci) {
+        for (var handler: goofyplugin$handlers) {
+            handler.accept(Either.left(t));
+        }
+        goofyplugin$handlers = null;
+    }
+
+    @Override
+    public Set<Consumer<Either<Throwable, T>>> goofyplugin$handlers() {
+        return goofyplugin$handlers;
+    }
+
+    @Override
+    public Throwable goofyplugin$errorObject() {
+        return errorObject;
+    }
+}

--- a/common/src/main/java/com/thekillerbunny/goofyplugin/mixin/ParticleEngineMixin.java
+++ b/common/src/main/java/com/thekillerbunny/goofyplugin/mixin/ParticleEngineMixin.java
@@ -1,0 +1,26 @@
+package com.thekillerbunny.goofyplugin.mixin;
+
+import net.minecraft.client.particle.Particle;
+import net.minecraft.client.particle.ParticleEngine;
+import org.figuramc.figura.avatar.AvatarManager;
+import org.figuramc.figura.lua.api.particle.LuaParticle;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ParticleEngine.class)
+public class ParticleEngineMixin {
+    @Inject(at = @At("HEAD"), method = "add", cancellable = true)
+    private void figura$checkParticle(Particle particle, CallbackInfo ci) {
+        LuaParticle luaParticle = new LuaParticle("event", particle, null);
+        AvatarManager.executeAll("checkParticle", avatar -> {
+            var results = avatar.run("PARTICLE_CREATED", avatar.worldRender, luaParticle);
+            if (results == null) return;
+            for (int i = 0; i < results.narg(); i++) {
+                var value = results.arg(1);
+                if (value.isboolean() && value.toboolean()) ci.cancel();
+            }
+        });
+    }
+}

--- a/common/src/main/java/com/thekillerbunny/goofyplugin/nomixinducks/FiguraFutureMixinAccess.java
+++ b/common/src/main/java/com/thekillerbunny/goofyplugin/nomixinducks/FiguraFutureMixinAccess.java
@@ -1,0 +1,14 @@
+package com.thekillerbunny.goofyplugin.nomixinducks;
+
+import com.mojang.datafixers.util.Either;
+import org.luaj.vm2.LuaFunction;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+
+import java.util.Set;
+import java.util.function.Consumer;
+
+public interface FiguraFutureMixinAccess<T> {
+    Set<Consumer<Either<Throwable, T>>> goofyplugin$handlers();
+    Throwable goofyplugin$errorObject();
+}

--- a/common/src/main/resources/goofyplugin-common-accessors.mixins.json
+++ b/common/src/main/resources/goofyplugin-common-accessors.mixins.json
@@ -6,6 +6,7 @@
   "client": [
   ],
   "mixins": [
+    "AvatarAccessor",
     "FiguraLuaRuntimeAccess"
   ],
   "injectors": {

--- a/common/src/main/resources/goofyplugin-common.mixins.json
+++ b/common/src/main/resources/goofyplugin-common.mixins.json
@@ -10,6 +10,7 @@
     "EventsAPIMixin",
     "FiguraAPIManagerMixin",
     "FiguraDocsManagerMixin",
+    "FiguraFutureMixin",
     "FiguraGlobalsDocsMixin",
     "FiguraLuaRuntimeMixin",
     "GameRendererMixin",

--- a/common/src/main/resources/goofyplugin-common.mixins.json
+++ b/common/src/main/resources/goofyplugin-common.mixins.json
@@ -20,6 +20,7 @@
     "PlayerStatusWidgetMixin",
     "PlayerTabOverlayMixin",
     "ScreenMixin",
+    "ServerboundSignUpdatePacketMixin",
     "UserDataMixin"
   ],
   "injectors": {

--- a/common/src/main/resources/goofyplugin-common.mixins.json
+++ b/common/src/main/resources/goofyplugin-common.mixins.json
@@ -15,6 +15,7 @@
     "GameRendererMixin",
     "GuiMixin",
     "LevelRendererMixin",
+    "ParticleEngineMixin",
     "PlayerStatusWidgetMixin",
     "PlayerTabOverlayMixin",
     "ScreenMixin",


### PR DESCRIPTION
Add an event for modifying sign text

It takes the sign position (which allows deriving the rotation and type via `WorldAPI:getBlockState()`, a mutable array of lines, and whether it is the front side. This event is also only fired if chat messages are enabled.

Untested on Forge.

(cherry picked from commit 09cbc72ecd5108b52b91cfa348ff512ba10b671b)

(cherry picked from commit f304bbe41546f12d146fa16a3af01c19f5b8bacc)
