### PR TITLE
[1/1] feat: goofy:getCursorItem()

### DIFF
--- a/common/src/main/java/com/thekillerbunny/goofyplugin/lua/GoofyAPI.java
+++ b/common/src/main/java/com/thekillerbunny/goofyplugin/lua/GoofyAPI.java
@@ -27,6 +27,7 @@ import org.figuramc.figura.lua.LuaNotNil;
 import org.figuramc.figura.lua.LuaWhitelist;
 import org.figuramc.figura.lua.api.event.LuaEvent;
 import org.figuramc.figura.lua.api.nameplate.NameplateAPI;
+import org.figuramc.figura.lua.api.world.ItemStackAPI;
 import org.figuramc.figura.lua.docs.LuaMethodDoc;
 import org.figuramc.figura.lua.docs.LuaMethodOverload;
 import org.figuramc.figura.lua.docs.LuaTypeDoc;
@@ -180,6 +181,15 @@ public class GoofyAPI {
             GoofyPlugin.LOGGER.debug("[" + owner.entityName + "] - " + data);
         }
     }
+
+	/**
+	 * @see https://github.com/FiguraMC/Figura/pull/309
+	*/
+	@LuaMethodDoc("goofy.get_cursor_item")
+	@LuaWhitelist
+	public ItemStackAPI getCursorItem() {
+		return ItemStackAPI.verify(mc.player.containerMenu.getCarried());
+	}
 
     @LuaWhitelist
     @LuaMethodDoc(

--- a/common/src/main/resources/assets/goofyplugin/lang/en_us.json
+++ b/common/src/main/resources/assets/goofyplugin/lang/en_us.json
@@ -19,6 +19,7 @@
   "figura.docs.goofy.error_to_log": "Logs data to the Minecraft Log as an error.\nThis will only show up if your Minecraft instance has\nerror logging enabled (it is by default).\nCheck with goofy:isErrorEnabled()",
   "figura.docs.goofy.trace_to_log": "Logs data to the Minecraft Log as a stacktrace.\nThis will only show up if your Minecraft instance has\ntrace logging enabled.\nCheck with goofy:isTraceEnabled()",
   "figura.docs.goofy.is_debug_enabled": "Checks if debug logging is enabled",
+  "figura.docs.goofy.get_cursor_item": "Gets the item currently held by the cursor, or air if none is held",
   "figura.docs.goofy.is_info_enabled": "Checks if info logging is enabled",
   "figura.docs.goofy.is_warn_enabled": "Checks if warn logging is enabled",
   "figura.docs.goofy.is_error_enabled": "Checks if error logging is enabled",


### PR DESCRIPTION
**Stack:**

* https://github.com/Figura-Goofballs/GoofyPlugin/pull/112


---

feat: goofy:getCursorItem()

Adds `goofy:getCursorItem()`, which resolves FiguraMC/Figura#309.

